### PR TITLE
Added PR template for bug fix on GitHub

### DIFF
--- a/.github/merge_request_templates/BUG_FIX.md
+++ b/.github/merge_request_templates/BUG_FIX.md
@@ -1,0 +1,15 @@
+# 🐞 The problem
+
+What was happening and/or what was causing it 🔥
+
+Simply describe the bug/problem.
+
+# 💻 The fix
+
+Describe your solution to fix the bug 🐛🪓
+
+# 🖼 Screenshots
+
+| Before 🐛 | After ✨ |
+| --------- | -------- |
+|           |          |


### PR DESCRIPTION
# 🐞 The problem

What was happening and/or what was causing it 🔥

It wasn't a bug in this case, more like an enhancement.

# 💻 The fix

Before this PR the repo didn't have any GitHub template for opening new bug fixes. This code adds an option to select a new template to standardize new Pr's making code more readable and cleaner.

# 🖼 Screenshots

| Before :bug:  | After :sparkles:  |
| ------------- | ------------- |
![template_v](https://user-images.githubusercontent.com/66080437/138155940-a8f92d4c-4614-4558-aa59-d0a2fe9cf9df.png)|![template_b](https://user-images.githubusercontent.com/66080437/138156042-388c4bc7-bddc-4738-b1ae-a671e4810a00.png)